### PR TITLE
Feature/auth

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,10 +20,11 @@
     "containerEnv": {
         "PONTOS_DB_PASSWORD": "password",
         "PONTOS_TRAEFIK_LOG_LEVEL": "DEBUG",
-        "PONTOS_TRAEFIK_ACCESSLOG": "true"
-    }
+        "PONTOS_EMQX_LOG_LEVEL": "debug",
+        "PONTOS_JWT_SECRET": "dev_jwt_secret_do_not_use_in_production!"
+    },
     // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "uname -a",
+    "postCreateCommand": "bash .devcontainer/install-utility-scripts.sh"
     // Configure tool-specific properties.
     // "customizations": {},
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/install-utility-scripts.sh
+++ b/.devcontainer/install-utility-scripts.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install shell2http
+wget -q -O - https://github.com/msoap/shell2http/releases/download/v1.16.0/shell2http_1.16.0_linux_amd64.tar.gz | sudo tar xvz -C /usr/local/bin shell2http
+
+# Install jwt-cli
+wget -q -O - https://github.com/mike-engel/jwt-cli/releases/download/5.0.3/jwt-linux.tar.gz | sudo tar xvz -C /usr/local/bin jwt

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ For some basic example scripts to publish data to the MQTT interface, see the [e
 
 See https://github.com/MO-RISE/pontos-data-ingestor
 
-## Auth solution
-(WIP)
+## Authentication and Authorization
+Authentication is performed using JWT tokens by:
+* PostgREST (for reuqests to the API)
+* EMQX (for connections to the MQTT broker)
+respectively.
 
+The reverse proxy (Traefik) does not perform any form of auth (nether authentcation nor authorization)
+
+Example of creating a valid JWT token that includes a role for PostgREST and a specific acl configuration for EMQX:
+```
+jwt encode --exp=1w --secret=<your_secret> '{"role": "web_user", "acl": {"pub": ["PONTOS/<vessel_id>/<parameter_id>/+"]}}'
+```

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu
+
+EXPOSE 8080
+
+ENV JWT_ISSUER=
+ENV JWT_EXPIRY=
+ENV JWT_SECRET=
+
+# Install neccessary tools
+RUN apt-get update && apt-get install -y \
+    wget \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install shell2http
+RUN wget -q -O - https://github.com/msoap/shell2http/releases/download/v1.16.0/shell2http_1.16.0_linux_amd64.tar.gz | tar xvz -C /usr/local/bin shell2http
+
+# Install jwt-cli
+RUN wget -q -O - https://github.com/mike-engel/jwt-cli/releases/download/5.0.3/jwt-linux.tar.gz | tar xvz -C /usr/local/bin jwt
+
+ADD --chmod=+x generate_jwt.sh generate_jwt.sh
+CMD ["shell2http", "--500", "--form", "--export-all-vars", "POST:/", "./generate_jwt.sh"]

--- a/auth/generate_jwt.sh
+++ b/auth/generate_jwt.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+set -euo pipefail
+
+# Define a function to create a JSON object from all available variables matching 'prefix'
+jsonify_prefixed_variables() {
+    # Read the prefix to use
+    local prefix=$1
+
+    #Initialize with empty json
+    json={}
+
+    # Loop over extracted variables
+    while read -r var; do
+        # Extract the key (by removing the  prefix)
+        key="${var/"$prefix"/""}"
+        # key=$(echo "$var" | sed "s/^${prefix}//")
+        # and the value
+        value=$(printenv "$var")
+
+        # Update json with new field
+        json=$(jq '. += {"'"$key"'":"'"$value"'"}' <<< "$json")
+
+    done < <(compgen -v | grep "^${prefix}")
+
+    # Return
+    echo "$json"
+}
+
+# Extract variables from shell2http input
+form_data_json=$(jsonify_prefixed_variables "v_")
+
+# Extract variables from environment variables
+env_json=$(jsonify_prefixed_variables "JWT_CLAIM_")
+
+# Merged json (Note the order! Later entries overwrites earlier ones!)
+merged_json=$(echo "$form_data_json $env_json" | jq -s add | jq 'to_entries | reduce .[] as $item ({}; .[$item.key] = $item.value)')
+
+# Create token and return it
+token=$(
+    jwt encode \
+        --iss="$JWT_ISSUER" \
+        --exp="$JWT_EXPIRY" \
+        --secret="$JWT_SECRET" \
+        "$merged_json"
+    )
+
+echo "$token"

--- a/broker/acl.conf
+++ b/broker/acl.conf
@@ -1,0 +1,6 @@
+%% Allow subscriptions to the PONTOS root topic from anyone
+%% that is already authenticated
+{allow, all, subscribe, ["PONTOS/#"]}.
+
+%% Deny everything else
+{deny, all}.

--- a/database/docker-entrypoint-initdb.d/012-pontos-postgrest-setup.sql
+++ b/database/docker-entrypoint-initdb.d/012-pontos-postgrest-setup.sql
@@ -10,7 +10,8 @@ GRANT USAGE ON SCHEMA api_views TO web_anon;
 GRANT USAGE ON SCHEMA api_views TO web_user;
 
 -- This gives the specified role select rights to all future tables in the api_views schema created by pontos_user
-ALTER DEFAULT PRIVILEGES FOR USER pontos_user IN SCHEMA api_views GRANT SELECT ON TABLES TO web_anon;
+-- NOTE: We do not give the web_anon user any privileges here. It will be used only for allowing connections to the
+-- postgrest instance to view the API docs but not actually read any data from the tables/views.
 ALTER DEFAULT PRIVILEGES FOR USER pontos_user IN SCHEMA api_views GRANT SELECT ON TABLES TO web_user;
 
 -- Create views that will be available through the rest api

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -2,7 +2,45 @@ version: "3.8"
 
 services:
 
+  # Broker
+  emqx:
+    environment:
+      # Applying authn/authz only to the websocket listener as that is the only one publicly exposed
+      - EMQX_LISTENERS__WS__DEFAULT__ENABLE_AUTHN=true
+      - EMQX_LISTENERS__WS__DEFAULT__AUTHENTICATION__1__ENABLE=true
+      - EMQX_LISTENERS__WS__DEFAULT__AUTHENTICATION__1__MECHANISM=jwt
+      - EMQX_LISTENERS__WS__DEFAULT__AUTHENTICATION__1__ALGORITHM=hmac-based
+      - EMQX_LISTENERS__WS__DEFAULT__AUTHENTICATION__1__USE_JWKS=false
+      - EMQX_LISTENERS__WS__DEFAULT__AUTHENTICATION__1__SECRET=${PONTOS_JWT_SECRET}
+      - EMQX_LISTENERS__WS__DEFAULT__AUTHENTICATION__1__SECRET_BASE64_ENCODED=false
+
+      # Authorization must be global
+      - EMQX_AUTHORIZATION__NO_MATCH=deny
+      - EMQX_AUTHORIZATION__DENY_ACTION=disconnect
+    volumes:
+      - ./broker/acl.conf:/opt/emqx/etc/acl.conf
+
   # REST api
   api:
     environment:
-      - PGRST_DB_ANON_ROLE= # Disable anonymuous access by providing an empty value here
+      - PGRST_DB_ANON_ROLE=web_anon # Does NOT have read permissions!
+      - PGRST_OPENAPI_MODE=ignore-privileges # But we anyway show docs for the full API
+      - PGRST_OPENAPI_SECURITY_ACTIVE=true # And allow to manually input a JWT
+      - PGRST_JWT_SECRET=${PONTOS_JWT_SECRET}
+      - PGRST_JWT_SECRET_IS_BASE64=false
+
+  # JWT issuer
+  jwt:
+    build:
+      context: ./auth
+    environment:
+      - JWT_ISSUER="pontos-hub"
+      - JWT_EXPIRY=1w
+      - JWT_SECRET=${PONTOS_JWT_SECRET}
+      - JWT_CLAIM_role=web_user
+    labels:
+      - "pontos.expose=true"
+      - "traefik.http.routers.jwt.rule=PathPrefix(`/token`)"
+      - "traefik.http.routers.jwt.entryPoints=web"
+      - "traefik.http.middlewares.jwt-stripprefix.stripprefix.prefixes=/token"
+      - "traefik.http.routers.jwt.middlewares=jwt-stripprefix@docker"

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -11,7 +11,7 @@ services:
     environment:
       # General configuration
       - TRAEFIK_LOG_LEVEL=${PONTOS_TRAEFIK_LOG_LEVEL:-ERROR}
-      - TRAEFIK_ACCESSLOG=${PONTOS_TRAEFIK_ACCESSLOG:-false}
+      - TRAEFIK_ACCESSLOG=true
       - TRAEFIK_API_DASHBOARD=true
       - TRAEFIK_PROVIDERS_DOCKER=true
       - TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT=true
@@ -42,9 +42,9 @@ services:
     environment:
       - EMQX_NAME=pontos-hub
       - EMQX_HOST=127.0.0.1
-      - EMQX_ALLOW_ANONYMOUS=true
-      - EMQX_ACL_NOMATCH=allow
       - EMQX_RETAINER__BACKEND__STORAGE_TYPE=disc
+      - EMQX_LOG__CONSOLE_HANDLER__ENABLE=true
+      - EMQX_LOG__CONSOLE_HANDLER__LEVEL=${PONTOS_EMQX_LOG_LEVEL:-warning}
     labels:
       - "pontos.expose=true"
       - "traefik.http.routers.emqx-ws.rule=PathPrefix(`/mqtt`)"
@@ -77,13 +77,13 @@ services:
 
   # REST api
   api:
-    image: postgrest/postgrest:v10.1.2
+    image: postgrest/postgrest:v10.2.0
     restart: unless-stopped
     environment:
       - PGRST_DB_URI=postgres://authenticator:${PONTOS_DB_PASSWORD}@db:5432/pontos
       - PGRST_OPENAPI_SERVER_PROXY_URI=http://localhost/api
       - PGRST_DB_SCHEMAS=api_views
-      - PGRST_DB_ANON_ROLE=web_anon
+      - PGRST_DB_ANON_ROLE=web_user # Has read permissions!
     depends_on:
       - db
     labels:
@@ -93,6 +93,8 @@ services:
       - "traefik.http.routers.postgrest.service=postgrest-service"
       - "traefik.http.services.postgrest-service.loadbalancer.server.port=3000"
       - "traefik.http.middlewares.postgrest-stripprefix.stripprefix.prefixes=/api"
+      - "traefik.http.middlewares.postgrest-ratelimit.ratelimit.average=1"
+      - "traefik.http.middlewares.postgrest-ratelimit.ratelimit.period=10s"
       - "traefik.http.routers.postgrest.middlewares=postgrest-stripprefix@docker"
 
   # Swagger api docs

--- a/example.env
+++ b/example.env
@@ -11,7 +11,7 @@ PONTOS_TRAEFIK_DASHBOARD_PORT=8080              # default: 8080
 PONTOS_EMQX_DASHBOARD_PORT=8081                 # default: 8081
 
 PONTOS_TRAEFIK_LOG_LEVEL=ERROR                  # default: ERROR
-PONTOS_TRAEFIK_ACCESSLOG=false                  # default: false
+PONTOS_EMQX_LOG_LEVEL=warning                   # default: warning
 
 
 
@@ -23,4 +23,12 @@ PONTOS_ACME_EMAIL=your-email@address.com
 
 #### Optional configuration
 PONTOS_HUB_HTTPS_PORT=443                       # default: 443
+
+
+
+## AUTH: for docker-compose.auth.yml
+
+#### Required configuration
+PONTOS_JWT_SECRET=<generatesomethingveryrandomandkeepitverysecret>
+
 


### PR DESCRIPTION
A "semi-auth" solution:
* An issuer creates JWT tokens for anyone that wants access, by default, this means:
  * Read access to the REST API
  * Subscribe access to the MQTT API
* The tokens are valid for 1w before expiring
* The tokens can contain any extra claims that can be used to "categorize" the user (no GDPR sensitive info though!)
* The tokens are validated by PostgREST and EMQX respectively