### PR TITLE
Configuring rate limit on the ws listener, keeping queue size as the default.

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -42,8 +42,14 @@ services:
     environment:
       - EMQX_NAME=pontos-hub
       - EMQX_HOST=127.0.0.1
+      # Retained messages will be persisted to disc to ensure they survive reboots etc
       - EMQX_RETAINER__BACKEND__STORAGE_TYPE=disc
+      # Allow for subscribers to upgrade QoS, this removes the requirement on publishers to use QoS > 0
       - EMQX_MQTT__UPGRADE_QOS=true
+      # Rate limit the total number of published messages on the ws listener
+      - EMQX_LISTENERS__WS__DEFAULT__LIMITER__MESSAGE_IN__RATE=5000/s
+      - EMQX_LISTENERS__WS__DEFAULT__LIMITER__MESSAGE_IN__CAPACITY=5000
+      # Configure logging
       - EMQX_LOG__CONSOLE_HANDLER__ENABLE=true
       - EMQX_LOG__CONSOLE_HANDLER__LEVEL=${PONTOS_EMQX_LOG_LEVEL:-warning}
     labels:
@@ -130,7 +136,7 @@ services:
       - PG_CONNECTION_STRING=postgres://pontos_user:${PONTOS_DB_PASSWORD}@db:5432/pontos
       - PG_TABLE_NAME=vessel_data.master
       - PG_POOL_SIZE=3
-      - PARTITION_SIZE=100
+      - PARTITION_SIZE=1000
       - PARTITION_TIMEOUT=5
     depends_on:
       - emqx


### PR DESCRIPTION
Closes #32 