### PR TITLE
Adding a custom entrypoint

### DIFF
--- a/database/always-initdb.d/.gitkeep
+++ b/database/always-initdb.d/.gitkeep
@@ -1,0 +1,1 @@
+Until we have an actual file to put here

--- a/database/custom-entrypoint.sh
+++ b/database/custom-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+# Custom entrypoint to always run files in /always-initdb.d/
+# See https://github.com/docker-library/postgres/pull/496 for details.
+
+# shellcheck source=/dev/null
+source "$(which docker-entrypoint.sh)"
+
+docker_setup_env
+docker_create_db_directories
+
+# If root, restart as postgres user
+if [ "$(id -u)" = '0' ]; then
+	exec su-exec postgres "${BASH_SOURCE[0]}" "$@"
+fi
+
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+	docker_init_database_dir
+	pg_setup_hba_conf
+
+	# only required for '--auth[-local]=md5' on POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+
+	docker_temp_server_start "$@" -c max_locks_per_transaction=256
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+	docker_temp_server_stop
+else
+	docker_temp_server_start "$@"
+	docker_process_init_files /always-initdb.d/*
+	docker_temp_server_stop
+fi
+
+exec postgres "$@"

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -76,11 +76,13 @@ services:
     volumes:
       # Data volume
       - vol-pg-data:/var/lib/postgresql/data
-      # Initialization scripts
-      - ./database/docker-entrypoint-initdb.d/010-pontos-setup.sql:/docker-entrypoint-initdb.d/010-pontos-setup.sql
-      - ./database/docker-entrypoint-initdb.d/011-pontos-example-data.sql:/docker-entrypoint-initdb.d/011-pontos-example-data.sql
-      - ./database/docker-entrypoint-initdb.d/012-pontos-postgrest-setup.sql:/docker-entrypoint-initdb.d/012-pontos-postgrest-setup.sql
-      - ./database/docker-entrypoint-initdb.d/013-pontos-postgrest-authenticator-setup.sh:/docker-entrypoint-initdb.d/013-pontos-postgrest-authenticator-setup.sh
+      # Custom entrypoint
+      - ./database/custom-entrypoint.sh:/usr/local/bin/custom-entrypoint.sh
+      # Initialization scripts (run on first start)
+      - ./database/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d/
+      # Initialization scripts (run on every start!)
+      - ./database/always-initdb.d/:/always-initdb.d/
+    entrypoint: "custom-entrypoint.sh"
 
   # REST api
   api:


### PR DESCRIPTION
To allow loading files from /always-initd.d/ that will be run on every database startup. Will be used for database versioning. For now contains a .gitkeep file to keep the folder in the repo.

Closes #23 