### PR TITLE
Adding a generic way of performing (optional) initial tuning of the d…

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -86,6 +86,7 @@ services:
       POSTGRES_DB: pontos
       POSTGRES_USER: pontos_user
       POSTGRES_PASSWORD: ${PONTOS_DB_PASSWORD}
+      TIMESCALEDB_CHUNK_TIME_INTERVAL: ${PONTOS_DB_INITIAL_CHUNK_TIME_INTERVAL:-'24 hours'}
     volumes:
       # Data volume
       - vol-pg-data:/var/lib/postgresql/data

--- a/example.env
+++ b/example.env
@@ -13,6 +13,8 @@ PONTOS_EMQX_DASHBOARD_PORT=8081                 # default: 8081
 PONTOS_TRAEFIK_LOG_LEVEL=ERROR                  # default: ERROR
 PONTOS_EMQX_LOG_LEVEL=warning                   # default: warning
 
+PONTOS_DB_INITIAL_CHUNK_TIME_INTERVAL='24 hours'    # default: '24 hours'
+
 
 
 ## HTTPS: for docker-compose.https.yml


### PR DESCRIPTION
…atabase setup through environmental variables in the .env file. The first possible configuration that is exposed is the chunk-time-interval that will default to 24 hours.